### PR TITLE
[#127] Improve 'dist' target to create tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ dist: clean-build collect compile
 # We need to do this like this as 'zip' always uses the cwd as archive root.
 # And for the extension to work extension.js etc. need to be at the root.
 	cd $(BUILDDIR); zip -rq ../dist/hamster@projecthamster.wordpress.com.zip ./*
+	cd $(BUILDDIR); tar -czf ../dist/hamster@projecthamster.wordpress.com.tgz *
 	@ls -l dist
 
 docs:


### PR DESCRIPTION
Our `dist` target now also create a tarball of the extension that can
be extracted right into `~/.local/share/gnome-shell/extensions/` if we
want to install the extension manually and not via
`extensions.gnome.org`.
This avoids people clone the repository itself as done previously, which
would not work anymore anyways as the new structure does not match what
gnome shell extensions should look like.

Those new tarballs should be discributed as primary releases on github
in order to complement `extensions.gnome.org`.

Closes: #127
