### PR TITLE
[#151] Support for Gnome Shell 3.21

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,9 +14,11 @@
         "3.14",
         "3.16",
         "3.18",
-        "3.20"
+        "3.20",
+        "3.21",
+        "3.21.91"
     ],
     "url": "https://github.com/projecthamster/shell-extension.git",
     "uuid": "hamster@projecthamster.wordpress.com",
-    "version": 22
+    "version": 23
 }


### PR DESCRIPTION
This PR integrates the new GnomeShell 3.21 and the Debian (testing) release 3.21.91
