### PR TITLE
General refactoring and restructuring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.{css,html,scss,yml}]
+indent_size = 2
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -11,31 +11,17 @@
  *
  */
 
-// TODO - investigate usage of third party libs (d3/underscore/whatever)
-//        otherwise even most primitive operations are hardcore
-
-const Clutter = imports.gi.Clutter;
-const Config = imports.misc.config;
 const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
-const St = imports.gi.St;
 const Shell = imports.gi.Shell;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
-const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
-const PopupMenu = imports.ui.popupMenu;
-const PanelMenu = imports.ui.panelMenu;
-const Util = imports.misc.util;
-const Gettext = imports.gettext.domain('hamster-shell-extension');
-const _ = Gettext.gettext;
-const N_ = function(x) { return x; };
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
-const Stuff = Me.imports.stuff;
+const PanelWidget = Me.imports.widgets.panelWidget.PanelWidget;
 
 // dbus-send --session --type=method_call --print-reply --dest=org.gnome.Hamster /org/gnome/Hamster org.freedesktop.DBus.Introspectable.Introspect
 const ApiProxyIface = '<node> \
@@ -80,507 +66,138 @@ let WindowsProxy = Gio.DBusProxy.makeProxyWrapper(WindowsProxyIface);
 
 
 
-/* a little box or something */
-function HamsterBox() {
-    this._init.apply(this, arguments);
-}
 
-HamsterBox.prototype = {
-    __proto__: PopupMenu.PopupBaseMenuItem.prototype,
-
-    _init: function(itemParams) {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this, {reactive: false});
-
-        let box = new St.BoxLayout({style_class: 'hamster-box'});
-        box.set_vertical(true);
-
-        let label = new St.Label({style_class: 'hamster-box-label'});
-        label.set_text(_("What are you doing?"));
-        box.add(label);
-
-        this._textEntry = new St.Entry({name: 'searchEntry',
-                                        can_focus: true,
-                                        track_hover: true,
-                                        hint_text: _("Enter activity...")});
-        this._textEntry.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivated));
-        this._textEntry.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
-
-
-        box.add(this._textEntry);
-
-        // autocomplete popup - couldn't spark it up just yet
-        //this._popup = new PopupMenu.PopupComboMenu(this._textEntry);
-
-        label = new St.Label({style_class: 'hamster-box-label'});
-        label.set_text(_("Today's activities"));
-        box.add(label);
-
-        let scrollbox = new St.ScrollView({style_class: 'hamster-scrollbox'});
-        this._scrollAdjustment = scrollbox.vscroll.adjustment;
-        box.add(scrollbox);
-
-        // Since St.Table does not implement StScrollable, we create a
-        // container object that does.
-        let container = new St.BoxLayout({});
-        container.set_vertical(true);
-        scrollbox.add_actor(container);
-
-        this.activities = new St.Widget({style_class: 'hamster-activities',
-                                         layout_manager: new Clutter.TableLayout(),
-                                         reactive: true });
-        container.add(this.activities);
-
-        this.summaryLabel = new St.Label({style_class: 'summary-label'});
-        box.add(this.summaryLabel);
-
-
-        this.actor.add_child(box);
-
-        this.autocompleteActivities = [];
-        this.runningActivitiesQuery = null;
-
-        this._prevText = "";
-    },
-
-    focus: function() {
-        Mainloop.timeout_add(20, Lang.bind(this, function() {
-            // scroll the activities to the bottom
-            this._scrollAdjustment.value = this._scrollAdjustment.upper;
-
-            // focus the text entry
-            global.stage.set_key_focus(this._textEntry);
-        }));
-    },
-
-    blur: function() {
-        global.stage.set_key_focus(null);
-    },
-
-    _onEntryActivated: function() {
-        this.emit('activate');
-        this._textEntry.set_text('');
-    },
-
-
-    _getActivities: function() {
-        if (this.runningActivitiesQuery)
-            return this.autocompleteActivities;
-
-        this.runningActivitiesQuery = true;
-        this.proxy.GetActivitiesRemote("", Lang.bind(this, function([response], err) {
-            this.runningActivitiesQuery = false;
-            this.autocompleteActivities = response;
-        }));
-
-        return this.autocompleteActivities;
-    },
-
-    _onKeyReleaseEvent: function(textItem, evt) {
-        let symbol = evt.get_key_symbol();
-        let text = this._textEntry.get_text().toLowerCase();
-        let starttime = "";
-        let activitytext = text;
-
-        // Don't include leading times in the activity autocomplete
-        let match = [];
-        if ((match = text.match(/^\d\d:\d\d /)) ||
-            (match = text.match(/^-\d+ /))) {
-            starttime = text.substring(0, match[0].length);
-            activitytext = text.substring(match[0].length);
-        }
-
-        // if nothing has changed or we still have selection then that means
-        // that special keys are at play and we don't attempt to autocomplete
-        if (activitytext == "" ||
-            this._prevText == text ||
-            this._textEntry.clutter_text.get_selection()) {
-            return;
-        }
-        this._prevText = text;
-
-        // ignore deletions
-        let ignoreKeys = [Clutter.BackSpace, Clutter.Delete, Clutter.Escape];
-        for (var key of ignoreKeys) {
-            if (symbol == key)
-                return;
-        }
-
-
-        let allActivities = this._getActivities();
-        for (var rec of allActivities) {
-            let completion = rec[0];
-            if (rec[1].length > 0)
-                completion += "@" + rec[1];
-            if (completion.toLowerCase().substring(0, activitytext.length) == activitytext) {
-                this.prevText = text;
-                completion = starttime + completion;
-
-                this._textEntry.set_text(completion);
-                this._textEntry.clutter_text.set_selection(text.length, completion.length);
-
-                this._prevText = completion.toLowerCase();
-
-                return;
-            }
-        }
-    }
-};
-
-
-
-/* Panel button */
-function HamsterExtension(extensionMeta) {
-    this._init(extensionMeta);
-}
-
-HamsterExtension.prototype = {
-    __proto__: PanelMenu.Button.prototype,
-
-    _init: function(extensionMeta) {
-        PanelMenu.Button.prototype._init.call(this, 0.0);
-
-        this.extensionMeta = extensionMeta;
-        this._proxy = new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster');
-        this._proxy.connectSignal('FactsChanged',      Lang.bind(this, this.refresh));
-        this._proxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
-        this._proxy.connectSignal('TagsChanged',       Lang.bind(this, this.refresh));
-
-
-        this._windowsProxy = new WindowsProxy(Gio.DBus.session,
-                                              "org.gnome.Hamster.WindowServer",
-                                              "/org/gnome/Hamster/WindowServer");
-
-        this._settings = Convenience.getSettings();
-
-
-        this.panelContainer = new St.BoxLayout({style_class: "panel-box"});
-        this.actor.add_actor(this.panelContainer);
-        this.actor.add_style_class_name('panel-status-button');
-
-
-        this.panelLabel = new St.Label({text: _("Loading..."),
-                                        y_align: Clutter.ActorAlign.CENTER});
-        this.currentActivity = null;
-
-        // panel icon
-        this._trackingIcon = Gio.icon_new_for_string(this.extensionMeta.path + "/images/hamster-tracking-symbolic.svg");
-        this._idleIcon = Gio.icon_new_for_string(this.extensionMeta.path + "/images/hamster-idle-symbolic.svg");
-
-        this.icon = new St.Icon({gicon: this._trackingIcon,
-                                 icon_size: 16,
-                                 style_class: "panel-icon"});
-
-        this.panelContainer.add(this.icon);
-        this.panelContainer.add(this.panelLabel);
-
-        let item = new HamsterBox();
-        item.connect('activate', Lang.bind(this, this._onActivityEntry));
-        this.activityEntry = item;
-        this.activityEntry.proxy = this._proxy; // lazy proxying
-
-
-        this.menu.addMenuItem(item);
-
-        // overview
-        item = new PopupMenu.PopupMenuItem(_("Show Overview"));
-        item.connect('activate', Lang.bind(this, this._onShowHamsterActivate));
-        this.menu.addMenuItem(item);
-
-        // stop tracking
-        item = new PopupMenu.PopupMenuItem(_("Stop Tracking"));
-        item.connect('activate', Lang.bind(this, this._onStopTracking));
-        this.menu.addMenuItem(item);
-
-        // add new task
-        item = new PopupMenu.PopupMenuItem(_("Add Earlier Activity"));
-        item.connect('activate', Lang.bind(this, this._onNewFact));
-        this.menu.addMenuItem(item);
-
-        // settings
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        item = new PopupMenu.PopupMenuItem(_("Tracking Settings"));
-        item.connect('activate', Lang.bind(this, this._onShowSettingsActivate));
-        this.menu.addMenuItem(item);
-
-
-        // focus menu upon display
-        this.menu.connect('open-state-changed', Lang.bind(this,
-            function(menu, open) {
-                if (open) {
-                    this.activityEntry.focus();
-                } else {
-                    this.activityEntry.blur();
-                }
-            }
-        ));
-
-
-        // load data
-        this.facts = null;
-        // refresh the label every 60 secs
-        this.timeout = GLib.timeout_add_seconds(0, 60, Lang.bind(this, this.refresh));
-        this.refresh();
-    },
-
-    show: function() {
-        this.menu.open();
-    },
-
-    toggle: function() {
-        this.menu.toggle();
-    },
-
-    refreshActivities: function(proxy, sender) {
-        this.activityEntry.autocompleteActivities = [];
-        this.refresh();
-    },
-
-    refresh: function(proxy, sender) {
-        this._proxy.GetTodaysFactsRemote(Lang.bind(this, this._refresh));
-        return true;
-    },
-
-    _refresh: function([response], err) {
-        let facts = [];
-
-        if (err) {
-            log(err);
-        } else if (response.length > 0) {
-            facts = Stuff.fromDbusFacts(response);
-        }
-
-        this.currentActivity = null;
-        let fact = null;
-        if (facts.length) {
-            fact = facts[facts.length - 1];
-            if (!fact.endTime)
-                this.currentActivity = fact;
-        }
-        this.updatePanelDisplay(fact);
-
-        let activities = this.activityEntry.activities;
-        activities.destroy_all_children(); // remove previous entries
-
-        var i = 0;
-        let layout = activities.layout_manager;
-        for (var fact of facts) {
-            let label;
-
-            label = new St.Label({style_class: 'cell-label'});
-            let text = "%02d:%02d - ".format(fact.startTime.getHours(), fact.startTime.getMinutes());
-            if (fact.endTime) {
-                text += "%02d:%02d".format(fact.endTime.getHours(), fact.endTime.getMinutes());
-            }
-            label.set_text(text);
-            layout.pack(label, 0, i);
-
-            label = new St.Label({style_class: 'cell-label'});
-            label.set_text(fact.name + (0 < fact.tags.length ? (" #" + fact.tags.join(", #")) : ""));
-            layout.pack(label, 1, i);
-
-            label = new St.Label({style_class: 'cell-label'});
-            label.set_text(Stuff.formatDurationHuman(fact.delta));
-            layout.pack(label, 2, i);
-
-
-            let icon;
-            let button;
-
-            button = new St.Button({style_class: 'clickable cell-button'});
-
-            icon = new St.Icon({icon_name: "document-open-symbolic",
-                                icon_size: 16});
-
-            button.set_child(icon);
-            button.fact = fact;
-            button.connect('clicked', Lang.bind(this, function(button, event) {
-                this._windowsProxy.editSync(GLib.Variant.new('i', [button.fact.id]));
-                this.menu.close();
-            }));
-            layout.pack(button, 3, i);
-
-
-            if (!this.currentActivity ||
-                this.currentActivity.name != fact.name ||
-                this.currentActivity.category != fact.category ||
-                this.currentActivity.tags.join(",") != fact.tags.join(",")) {
-                button = new St.Button({style_class: 'clickable cell-button'});
-
-                icon = new St.Icon({icon_name: "media-playback-start-symbolic",
-                                    icon_size: 16});
-
-                button.set_child(icon);
-                button.fact = fact;
-
-                button.connect('clicked', Lang.bind(this, function(button, event) {
-                    let factStr = button.fact.name
-                                  + "@" + button.fact.category
-                                  + ", " + (button.fact.description);
-                    if (button.fact.tags.length) {
-                        factStr += " #" + button.fact.tags.join(", #");
-                    }
-
-                    this._proxy.AddFactRemote(factStr, 0, 0, false, Lang.bind(this, function(response, err) {
-                        // not interested in the new id - this shuts up the warning
-                    }));
-                    this.menu.close();
-                }));
-                layout.pack(button, 4, i);
-            }
-
-            i += 1;
-        }
-
-        let byCategory = {};
-        let categories = [];
-        for (var fact of facts) {
-            byCategory[fact.category] = (byCategory[fact.category] || 0) + fact.delta;
-            if (categories.indexOf(fact.category) == -1)
-                categories.push(fact.category);
-        }
-
-        let label = "";
-        for (var category of categories) {
-            label += category + ": " + Stuff.formatDurationHours(byCategory[category]) +  ", ";
-        }
-        label = label.slice(0, label.length - 2); // strip trailing comma
-        this.activityEntry.summaryLabel.set_text(label);
-    },
-
-
-    updatePanelDisplay: function(fact) {
-        // 0 = show label, 1 = show icon + duration, 2 = just icon
-        let appearance = this._settings.get_int("panel-appearance");
-
-
-        if (appearance === 0) {
-            this.panelLabel.show();
-            this.icon.hide();
-
-            if (fact && !fact.endTime) {
-                this.panelLabel.text = "%s %s".format(fact.name, Stuff.formatDuration(fact.delta));
-            } else {
-                this.panelLabel.text = _("No activity");
-            }
-        } else {
-            this.icon.show();
-            if (appearance == 1)
-                this.panelLabel.hide();
-            else
-                this.panelLabel.show();
-
-
-            // updates panel label. if fact is none, will set panel status to "no activity"
-            if (fact && !fact.endTime) {
-                this.panelLabel.text = Stuff.formatDuration(fact.delta);
-                this.icon.gicon = this._trackingIcon;
-            } else {
-                this.panelLabel.text = "";
-                this.icon.gicon = this._idleIcon;
-            }
-        }
-    },
-
-
-    _onStopTracking: function() {
-        let now = new Date();
-        let epochSeconds = Date.UTC(now.getFullYear(),
-                                    now.getMonth(),
-                                    now.getDate(),
-                                    now.getHours(),
-                                    now.getMinutes(),
-                                    now.getSeconds());
-        epochSeconds = Math.floor(epochSeconds / 1000);
-        this._proxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
-    },
-
-    _onShowHamsterActivate: function() {
-        this._windowsProxy.overviewSync();
-    },
-
-    _onNewFact: function() {
-        this._windowsProxy.editSync(GLib.Variant.new('i', [0]));
-    },
-
-    _onShowSettingsActivate: function() {
-        this._windowsProxy.preferencesSync();
-    },
-
-
-    _onActivityEntry: function() {
-        let text = this.activityEntry._textEntry.get_text();
-        this._proxy.AddFactRemote(text, 0, 0, false, Lang.bind(this, function(response, err) {
-            // not interested in the new id - this shuts up the warning
-        }));
-    }
-};
-
-
-function ExtensionController(extensionMeta) {
+/**
+ * Create the controller instance that handles extension context.
+ *
+ * This class does not actually handle any widgets/representation itself. It is
+ * instead in charge of setting up the general infrastructure and to make sure
+ * that the extension cleans up after itself if it gets deactivated.
+ *
+ * @class
+ */
+function Controller(extensionMeta) {
     let dateMenu = Main.panel.statusArea.dateMenu;
 
     return {
         extensionMeta: extensionMeta,
-        extension: null,
+        panelWidget: null,
         settings: null,
         placement: 0,
-        activitiesText: null,
+        apiProxy:  new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster'),
+        windowsProxy: new WindowsProxy(Gio.DBus.session, "org.gnome.Hamster.WindowServer",
+            "/org/gnome/Hamster/WindowServer"),
 
         enable: function() {
             this.settings = Convenience.getSettings();
-            this.extension = new HamsterExtension(this.extensionMeta);
-
+            this.panelWidget = new PanelWidget(this);
             this.placement = this.settings.get_int("panel-placement");
-            if (this.placement == 1) {
-                Main.panel.addToStatusArea("hamster", this.extension, 0, "center");
 
-                Main.panel._centerBox.remove_actor(dateMenu.container);
-                Main.panel._addToPanelBox('dateMenu', dateMenu, -1, Main.panel._rightBox);
+            this._placeWidget(this.placement, this.panelWidget)
+            this.apiProxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
+            this.activities = this.refreshActivities();
 
-            } else if (this.placement == 2) {
-                this._activitiesText = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0].get_text();
-                Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0].set_text('');
-                Main.panel.addToStatusArea("hamster", this.extension, 1, "left");
-
-            } else {
-                Main.panel.addToStatusArea("hamster", this.extension, 0, "right");
-            }
-
-            Main.panel.menuManager.addMenu(this.extension.menu);
-
-
+            Main.panel.menuManager.addMenu(this.panelWidget.menu);
             Main.wm.addKeybinding("show-hamster-dropdown",
-                this.extension._settings,
+                this.panelWidget._settings,
                 Meta.KeyBindingFlags.NONE,
-                //since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
+                // Since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
                 Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
-                Lang.bind(this.extension, this.extension.toggle)
+                Lang.bind(this.panelWidget, this.panelWidget.toggle)
             );
         },
 
         disable: function() {
             Main.wm.removeKeybinding("show-hamster-dropdown");
 
-            if (this.placement == 1) {
+            this._removeWidget(this.placement)
+            Main.panel.menuManager.removeMenu(this.panelWidget.menu);
+            GLib.source_remove(this.panelWidget.timeout);
+            this.panelWidget.actor.destroy();
+            this.panelWidget.destroy();
+            this.panelWidget = null;
+        },
+
+        /**
+         * Build a new cache of all activities present in the backend.
+         */
+        refreshActivities: function() {
+            /**
+             * Return an Array of [Activity.name, AcAivity.category.name] Arrays.
+             *
+             */
+            function getActivities(controller) {
+                // [FIXME]
+                // It seems preferable to have a sync methods call in order to
+                // avoid race conditions (previously extensions used async
+                // version).
+                // There is however a reasonable risk this may actually be a bad
+                // idea as it may block the entire shell if the request takes too
+                // long. This may be particulary likly if the dbus service uses
+                // a remote database as persistent storage.
+                // We need to come back to this once we have the low hanging fruits
+                // covered.
+                let activities = controller.apiProxy.GetActivitiesSync('');
+                // [FIXME]
+                // For some bizare reason I am unable to create a proper array out
+                // of the return value of the dbus method call any other way.
+                // So unless can provide some insight here, this hack does the job.
+                let foo = function([activities]){return activities;};
+                return foo(activities);
+            };
+
+            let result = getActivities(this);
+            this.activities = result;
+            return result;
+        },
+
+        /**
+         * Place the actual extension wi
+         * get in the right place according to settings.
+         */
+        _placeWidget: function(placement, panelWidget) {
+            if (placement == 1) {
+                // 'Replace calendar'
+                Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "center");
+
+                Main.panel._centerBox.remove_actor(dateMenu.container);
+                Main.panel._addToPanelBox('dateMenu', dateMenu, -1, Main.panel._rightBox);
+            } else if (placement == 2) {
+                // 'Replace activities'
+                let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0]
+                // If our widget replaces the 'Activities' menu in the panel,
+                // this property stores the original text so we can restore it
+                // on ``this.disable``.
+                this._activitiesText = activitiesMenu.get_text();
+                activitiesMenu.set_text('');
+                Main.panel.addToStatusArea("hamster", this.panelWidget, 1, "left");
+            } else {
+                // 'Default'
+                Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "right");
+            };
+        },
+
+        _removeWidget: function(placement) {
+            if (placement == 1) {
+                // We replaced the calendar
                 Main.panel._rightBox.remove_actor(dateMenu.container);
-                Main.panel._addToPanelBox('dateMenu', dateMenu, Main.sessionMode.panel.center.indexOf('dateMenu'), Main.panel._centerBox);
-
-            } else if (this.placement == 2) {
-                Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0].set_text(this._activitiesText);
-            }
-
-            Main.panel.menuManager.removeMenu(this.extension.menu);
-
-            GLib.source_remove(this.extension.timeout);
-            this.extension.actor.destroy();
-            this.extension.destroy();
-            this.extension = null;
-        }
+                Main.panel._addToPanelBox(
+                    'dateMenu',
+                    dateMenu,
+                    Main.sessionMode.panel.center.indexOf('dateMenu'),
+                    Main.panel._centerBox
+                );
+            } else if (placement == 2) {
+                // We replaced the 'Activities' menu
+                let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0]
+                activitiesMenu.set_text(this._activitiesText);
+            };
+        },
     };
-}
+};
 
 
 function init(extensionMeta) {
     Convenience.initTranslations("hamster-shell-extension");
-    return new ExtensionController(extensionMeta);
+    return new Controller(extensionMeta);
 }

--- a/extension/stuff.js
+++ b/extension/stuff.js
@@ -32,7 +32,7 @@ function fromDbusFact(fact) {
         return new Date(res.setUTCMinutes(res.getUTCMinutes() + res.getTimezoneOffset()));
     }
 
-    return {
+    result = {
         name: fact[4],
         startTime: UTCToLocal(fact[1]*1000),
         endTime: fact[2] != 0 ? UTCToLocal(fact[2]*1000) : null,
@@ -44,6 +44,7 @@ function fromDbusFact(fact) {
         delta: Math.floor(fact[9] / 60), // minutes
         id: fact[0]
     };
+    return result;
 };
 
 function fromDbusFacts(facts) {

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -1,0 +1,48 @@
+const Lang = imports.lang;
+const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Stuff = Me.imports.stuff;
+
+
+/**
+ * Custom Label widget that displays category totals.
+ */
+const CategoryTotalsWidget = new Lang.Class({
+    Name: 'CategoryTotals',
+    Extends: St.Label,
+
+    _init: function() {
+        this.parent({style_class: 'summary-label'});
+
+    },
+
+    /**
+     * Recompute values and replace old string with new one based on passed facts.
+     */
+    refresh: function(facts) {
+        /**
+         * Construct a string representing category totals.
+         */
+        function getString(facts) {
+            let byCategory = {};
+            let categories = [];
+            for (let fact of facts) {
+                byCategory[fact.category] = (byCategory[fact.category] || 0) + fact.delta;
+                if (categories.indexOf(fact.category) == -1)
+                    categories.push(fact.category);
+            };
+
+            let string = "";
+            for (let category of categories) {
+                string += category + ": " + Stuff.formatDurationHours(byCategory[category]) +  ", ";
+            };
+            // strip trailing comma
+            return string.slice(0, string.length - 2);
+        };
+
+        this.set_text(getString(facts))
+    },
+});

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -1,0 +1,84 @@
+const Lang = imports.lang;
+const St = imports.gi.St;
+const PopupMenu = imports.ui.popupMenu
+const Clutter = imports.gi.Clutter;
+const Mainloop = imports.mainloop;
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Stuff = Me.imports.stuff;
+const OngoingFactEntry = Me.imports.widgets.ongoingFactEntry.OngoingFactEntry
+const CategoryTotalsWidget = Me.imports.widgets.categoryTotalsWidget.CategoryTotalsWidget
+const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
+
+
+/**
+ * Create the widget that ``PanelWidget`` will use to dispay the *raw fact entry* as
+ * well as todays facts.
+ * @class
+ */
+const FactsBox = new Lang.Class({
+    Name: 'FactsBox',
+    Extends: PopupMenu.PopupBaseMenuItem,
+    _init: function(controller, panelWidget) {
+        this.parent({reactive: false});
+
+        this._controller = controller
+
+        // Setup main layout box
+        let main_box = new St.BoxLayout({style_class: 'hamster-box'});
+        main_box.set_vertical(true);
+        this.actor.add_child(main_box);
+
+        // Setup *ongoing fact* label and widget
+        let _ongoingFactLabel = new St.Label({style_class: 'hamster-box-label'});
+        _ongoingFactLabel.set_text(_("What are you doing?"));
+        main_box.add(_ongoingFactLabel);
+
+        this.ongoingFactEntry = new OngoingFactEntry(this._controller);
+        //this.ongoingFactEntry.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
+        main_box.add(this.ongoingFactEntry);
+
+        let fact_list_label = new St.Label({style_class: 'hamster-box-label'});
+        fact_list_label.set_text(_("Today's activities"));
+        main_box.add(fact_list_label);
+
+        // Scrollbox that will house the list of todays facts
+        // Since ``St.Table`` does not implement St.Scrollable, we create a
+        // container object that does.
+        this.todaysFactsWidget = new TodaysFactsWidget(this._controller, panelWidget);
+        this._scrollAdjustment = this.todaysFactsWidget.vscroll.adjustment;
+        main_box.add(this.todaysFactsWidget);
+
+        // Setup category summery
+        this.summaryLabel = new CategoryTotalsWidget()
+        main_box.add(this.summaryLabel);
+    },
+
+    // [FIXME]
+    // The best solution would be to listen for a 'FactsChanged' Signal that carries the new
+    // facts as payload and just refresh with this. But for now we stick with this
+    // simpler version.
+    refresh: function(facts, ongoingFact) {
+        this.todaysFactsWidget.refresh(facts, ongoingFact);
+        this.summaryLabel.refresh(facts);
+
+    },
+
+    /**
+     * Focus the fact entry and make sure todaysFactsWidget are scrolled to the bottom.
+     */
+    focus: function() {
+        Mainloop.timeout_add(20, Lang.bind(this, function() {
+            this._scrollAdjustment.value = this._scrollAdjustment.upper;
+            global.stage.set_key_focus(this.ongoingFactEntry);
+        }));
+    },
+
+    /**
+     * Remove any existing focus.
+     */
+    unfocus: function() {
+        global.stage.set_key_focus(null);
+    },
+});

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -1,0 +1,162 @@
+const Lang = imports.lang;
+const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+
+
+/**
+ * Custom Entry widget that allows entering a *raw fact* string for a new ongoing fact.
+ *
+ * Besides general layout this widget is also in charge of providing autocomplete functionality.
+ * @class
+ *
+ *
+ */
+const OngoingFactEntry = new Lang.Class({
+    Name: 'OngoingFactEntry',
+    Extends: St.Entry,
+
+    _init: function(controller) {
+        this.parent({
+            name: 'searchEntry',
+            can_focus: true,
+            track_hover: true,
+            hint_text: _("Enter activity...")
+        });
+
+        this._controller = controller
+        this._prevText = ''
+        // Seems to be populate by GetActivities.
+        this._autocompleteActivities = [];
+        this._runningActivitiesQuery = null;
+        this.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivated));
+        this.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
+    },
+
+    /**
+     * Callback for when ``ongoingFactEntry`` gets activated.
+     *
+     * Passes the current widget text as 'raw fact' to the dbus interface in order
+     * to create a new 'ongoing fact'.
+     * Also resets the text to an empty string afterwards.
+     *
+     * @callback FactsBox~_onEntryActivated
+     */
+    _onEntryActivated: function() {
+        let text = this.get_text();
+        this._controller.apiProxy.AddFactRemote(text, 0, 0, false, Lang.bind(this, function(response, error) {
+            // not interested in the new id - this shuts up the warning
+        }));
+        this.set_text('');
+    },
+
+    /**
+     * Callback triggered after key release.
+     *
+     * This is where autocompletion happens.
+     *
+     * @callback FactsBox~_onKeyReleaseEvent
+     */
+    _onKeyReleaseEvent: function(textItem, evt) {
+        /**
+         * Check if the passed key is on our list of keys to be ignored.
+         */
+        function checkIfIgnoredKey(key) {
+            let ignoreKeys = [Clutter.BackSpace, Clutter.Delete, Clutter.Escape];
+            // Looks like there is realy no ``Array.includes()`` available as
+            // of now.
+            let result = ignoreKeys.indexOf(key);
+            if (result == -1) {
+                result = false;
+            } else{
+                result = true;
+            };
+            return result;
+        };
+
+        let symbol = evt.get_key_symbol();
+        // [FIXME]
+        // To limit the scope of the PR we did not refactor this bit too much.
+        // We should however take another look at the Instance attributes and
+        // see what is really needed and if their naming is apropriate.
+        let text = this.get_text().toLowerCase();
+        let starttime = "";
+        let activitytext = text;
+
+        // [FIXME]
+        // Should be a separate function.
+        //
+        // Don't include leading times in the activity autocomplete
+        // [FIXME] Even if the parsing is not flawed (which it most likly is,
+        // the variable names are certainly off.
+        // [FIXME]
+        // If we allow the whole host of raw fact parsing we need to extend our
+        // regex.
+        let match = [];
+        if ((match = text.match(/^\d\d:\d\d /)) ||
+            (match = text.match(/^-\d+ /))) {
+            starttime = text.substring(0, match[0].length);
+            activitytext = text.substring(match[0].length);
+        };
+
+        // [FIXME]
+        // Should be a separate local function.
+        //
+        // If nothing has changed or we still have selection then that means
+        // that special keys are at play and we don't attempt to autocomplete
+        if (activitytext == "" ||
+            this._prevText == text ||
+            this.clutter_text.get_selection()) {
+            return;
+        }
+        this._prevText = text;
+
+        if (checkIfIgnoredKey(symbol)) { return };
+
+        // [FIXME]
+        // Investigate if we can move this into a dedicated 'autocomplete' function.
+        //
+        // Autocomplete
+        // If a key release has been detected: itterate over all activities fetched from the backend
+        // (via GetActivities aka __get_activities. This is a list of
+        // (activity.name, activivty.category.name) tuples.
+        // for each item: If it has a category, construct new composite string 'name@category',
+        // else just use 'name'.
+        //
+        // For each activity we now do the following:
+        // - Check if the current iteration item string has the current
+        //   entry text as a substring starting from 0 (remember that the iteration item may be
+        //  'activity@category'.
+        //
+        // - If so: We got a hit (if there are multiple, only the first item that triggers the match
+        //   will be considered. Further filtering happens due to continued typing, there is no selection
+        //   or visual feedback that there was more than one hit.
+        // - Now we build a new 'result string' like this 'starttime iterationitem'. starttime is
+        //   an empty string at the beginning.
+        // - Set the iteration item as new entry text
+        // - Select the bit after actually typed text to the end of iteration item. This should
+        //   result in removal of the "unmatched bits" once user continues typing
+        // - Store a normalized (lower) version of the iteration item (and now new text) in a local
+        //  tmo variable. This is used to check against the entry text after new button releases
+        //  to see if things have changed.
+        //
+        //  If not, do nothing.
+        for (let activity of this._controller.activities) {
+            let name = activity[0];
+            let category = activity[1];
+            let activityString = name;
+            if (category.length > 0) {
+                activityString = name + "@" + category;
+            }
+            // We got a hit.
+            if (activityString.toLowerCase().substring(0, activitytext.length) == activitytext) {
+                let completion = starttime + activityString;
+                this.set_text(completion);
+                this.get_clutter_text().set_selection(text.length, completion.length);
+
+                this._prevText = completion.toLowerCase();
+            };
+        };
+    },
+});

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -1,0 +1,287 @@
+const Lang = imports.lang;
+const Gio = imports.gi.Gio;
+const Clutter = imports.gi.Clutter;
+const PanelMenu = imports.ui.panelMenu;
+const St = imports.gi.St;
+const PopupMenu = imports.ui.popupMenu
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const FactsBox = Me.imports.widgets.factsBox.FactsBox;
+const Stuff = Me.imports.stuff;
+
+/**
+ * Class that defines the actual extension widget to be shown in the panel.
+ *
+ *  -------------------------------------------------------------
+ *  | Gnome top menu bar  | PanelWidget / PanelWidget.panelLabel|
+ *  -------------------------------------------------------------
+ *                        |PanelWidget.menu                     |
+ *                        |                                     |
+ *                        |PanelWidget.factsBox                 |
+ *                        |                                     |
+ *                        |PanelWidget.overviewMenuItem         |
+ *                        |PanelWidget.stopTrackingMenuItem     |
+ *                        |PanelWidget.addNewFactMenuItem       |
+ *                        |PanelWidget.SettingMenuItem          |
+ *                        |                                     |
+ *                        ---------------------------------------
+ *
+ * @class
+ */
+const PanelWidget = new Lang.Class({
+    Name: 'PanelWidget',
+    Extends: PanelMenu.Button,
+
+    _init: function(controller) {
+        // [FIXME]
+        // What is the parameter?
+        this.parent(0.0);
+
+        this._controller = controller
+        // [FIXME]
+        // Still needed?
+        this._extensionMeta = controller.extensionMeta;
+        this._settings = controller.settings;
+        this._windowsProxy = controller.windowsProxy;
+
+        controller.apiProxy.connectSignal('FactsChanged',      Lang.bind(this, this.refresh));
+        controller.apiProxy.connectSignal('TagsChanged',       Lang.bind(this, this.refresh));
+
+
+        // Setup the main layout container for the part of the extension
+        // visible in the panel.
+        let panelContainer = new St.BoxLayout({style_class: "panel-box"});
+        this.actor.add_actor(panelContainer);
+        this.actor.add_style_class_name('panel-status-button');
+
+        this.panelLabel = new St.Label({
+            text: _("Loading..."),
+            y_align: Clutter.ActorAlign.CENTER
+        });
+
+        // If we want to switch icons, we actually keep the same instance and
+        // just swap the actual image.
+        // [FIXME]
+        // Is there no path manipulation lib?
+        this._trackingIcon = Gio.icon_new_for_string(this._extensionMeta.path + "/images/hamster-tracking-symbolic.svg");
+        this._idleIcon = Gio.icon_new_for_string(this._extensionMeta.path + "/images/hamster-idle-symbolic.svg");
+        this.icon = new St.Icon({gicon: this._trackingIcon,
+                                 icon_size: 16,
+                                 style_class: "panel-icon"});
+
+        panelContainer.add(this.icon);
+        panelContainer.add(this.panelLabel);
+
+        this.factsBox = new FactsBox(controller, this);
+        this.menu.addMenuItem(this.factsBox);
+
+        // overview
+        let overviewMenuItem = new PopupMenu.PopupMenuItem(_("Show Overview"));
+        overviewMenuItem.connect('activate', Lang.bind(this, this._onOpenOverview));
+        this.menu.addMenuItem(overviewMenuItem);
+
+        // [FIXME]
+        // This should only be shown if we have an 'ongoing fact'.
+        // stop tracking
+        let stopTrackinMenuItem = new PopupMenu.PopupMenuItem(_("Stop Tracking"));
+        stopTrackinMenuItem.connect('activate', Lang.bind(this, this._onStopTracking));
+        this.menu.addMenuItem(stopTrackinMenuItem);
+
+        // add new task
+        let addNewFactMenuItem = new PopupMenu.PopupMenuItem(_("Add Earlier Activity"));
+        addNewFactMenuItem.connect('activate', Lang.bind(this, this._onOpenAddFact));
+        this.menu.addMenuItem(addNewFactMenuItem);
+
+        // settings
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+        let SettingMenuItem = new PopupMenu.PopupMenuItem(_("Tracking Settings"));
+        SettingMenuItem.connect('activate', Lang.bind(this, this._onOpenSettings));
+        this.menu.addMenuItem(SettingMenuItem);
+
+        // focus menu upon display
+        this.menu.connect('open-state-changed', Lang.bind(this,
+            function(menu, open) {
+                if (open) {
+                    this.factsBox.focus();
+                } else {
+                    this.factsBox.unfocus();
+                }
+            }
+        ));
+
+        // refresh the widget every 60 secs
+        this.timeout = GLib.timeout_add_seconds(0, 60, Lang.bind(this, this.refresh));
+        this.refresh();
+    },
+
+    /**
+     * This is our main 'update/refresh' method.
+     * Whenever we suspect that things have changed (via dbus signals)
+     * this should be triggered.
+     * Upon such triggering, this method should call relevant sub-widget's
+     * 'refresh' method.
+     * As such it should do as little work as possible and rather gather all
+     * required facts etc and pass them to the relevant sub-widget's
+     * refresh methods.
+     */
+    refresh: function() {
+    /**
+     * We need to wrap our actual refresh code in this callback for now as
+     * I am having major difficulties using a syncronous dbus method call to
+     * fetch the array of 'todaysFacts'.
+     */
+	function _refresh([response], err) {
+        /**
+         * Extract *ongoing fact* from our list of facts. Due to how *legacy
+         * hamster* works this is the first element in the array returned my
+         * ``getTodayFacts``.
+         *
+         * Returns ``null`` if there is no *ongoing fact*.
+         */
+		function getOngoingFact(facts) {
+		    let result = null;
+		    if (facts.length) {
+			let lastFact = facts[facts.length - 1];
+			if (!lastFact.endTime) { result = lastFact };
+		    };
+		    return result;
+		};
+
+		let facts = [];
+
+        // [FIXME]
+        // This seems a rather naive way to handle potential errors.
+		if (err) {
+		    log(err);
+		} else if (response.length > 0) {
+		    facts = Stuff.fromDbusFacts(response);
+		};
+
+		let ongoingFact = getOngoingFact(facts);
+
+		this.updatePanelDisplay(ongoingFact);
+		this.factsBox.refresh(facts, ongoingFact);
+	};
+
+    // [FIXME]
+    // This should really be a synchronous call fetching the facts.
+    // Once this is done, the actual code from the callback should follow
+    // here.
+    this._controller.apiProxy.GetTodaysFactsRemote(Lang.bind(this, _refresh));
+    },
+
+    /**
+     * Open 'popup menu' containing the bulk of the extension widgets.
+     */
+    show: function() {
+        this.menu.open();
+    },
+
+    /**
+     * Close/Open the 'popup menu' depending on previous state.
+     */
+    toggle: function() {
+        this.menu.toggle();
+    },
+
+
+    /**
+     * Update the rendering of the PanelWidget in the panel itself.
+     *
+     * Depending on the 'display mode' set in the extensions settings this has
+     * slightly different consequences.
+     */
+    updatePanelDisplay: function(fact) {
+        /**
+         * Return a text string representing the passed fact suitable for the panelLabel.
+         *
+         * @param fact The fact to be represented. Be advised. If there is no
+         * *ongoing fact* this will be ``null``!
+         */
+        function getLabelString(fact) {
+            let result = _("No activity");
+            if (fact) {
+                result = "%s %s".format(fact.name, Stuff.formatDuration(fact.delta));
+            };
+            return result;
+        };
+        /**
+         * Returns the appropriate icon image depending on ``fact``.
+         */
+        function getIcon(panelWidget) {
+            let result = panelWidget._idleIcon;
+            if (fact) { result = panelWidget._trackingIcon };
+            return result;
+        };
+
+        // 0 = show label, 1 = show just icon, 2 = show label and icon
+        switch (this._settings.get_int("panel-appearance")) {
+            case 0:
+                this.panelLabel.set_text(getLabelString(fact));
+                this.panelLabel.show();
+                this.icon.hide();
+                break;
+            case 1:
+                this.icon.gicon = getIcon(this);
+                this.icon.show();
+                this.panelLabel.hide();
+                break;
+            case 2:
+                this.icon.gicon = getIcon(this);
+                this.icon.show();
+                this.panelLabel.set_text(getLabelString(fact));
+                this.panelLabel.show();
+                break;
+        };
+    },
+
+
+    /**
+     * Callback to be triggered when an *ongoing fact* is stopped.
+     * @callback PanelWidget~_onStopTracking
+     *
+     * This will get the current time and issue the ``StopTracking``
+     * method call to the dbus interface.
+     */
+    _onStopTracking: function() {
+        let now = new Date();
+        let epochSeconds = Date.UTC(now.getFullYear(),
+                                    now.getMonth(),
+                                    now.getDate(),
+                                    now.getHours(),
+                                    now.getMinutes(),
+                                    now.getSeconds());
+        epochSeconds = Math.floor(epochSeconds / 1000);
+        this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
+    },
+
+    /**
+     * Callback that triggers opening of the *Overview*-Window.
+     *
+     * @callback panelWidget~_onOpenOverview
+     */
+    _onOpenOverview: function() {
+        this._controller.windowsProxy.overviewSync();
+    },
+
+    /**
+     * Callback that triggers opening of the *Add Fact*-Window.
+     *
+     * @callback panelWidget~_onOpenAddFact
+     */
+    _onOpenAddFact: function() {
+        this._controller.windowsProxy.editSync(GLib.Variant.new('i', [0]));
+    },
+
+    /**
+     * Callback that triggers opening of the *Add Fact*-Window.
+     *
+     * @callback panelWidget~_onOpenSettings
+     *
+     * Note: This will open the GUI settings, not the extension settings!
+     */
+    _onOpenSettings: function() {
+        this._controller.windowsProxy.preferencesSync();
+    },
+});

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -1,0 +1,172 @@
+const Lang = imports.lang;
+const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Stuff = Me.imports.stuff;
+
+
+/**
+ * A widget that lists all facts for *today*.
+ */
+const TodaysFactsWidget = new Lang.Class({
+    Name: 'TodaysFactsWidget',
+    Extends: St.ScrollView,
+
+    _init: function(controller, panelWidget) {
+        this.parent({style_class: 'hamster-scrollbox'});
+        this._controller = controller;
+        this._panelWidget = panelWidget;
+
+
+        this.factsBox = new St.BoxLayout({});
+        this.factsBox.set_vertical(true);
+        this.facts_widget = new St.Widget({
+            style_class: 'hamster-activities',
+            layout_manager: new Clutter.TableLayout(),
+            reactive: true
+        });
+        this.factsBox.add(this.facts_widget);
+        this.add_actor(this.factsBox);
+
+    },
+
+    /**
+     * Populate the widget with rows representing the passed facts.
+     */
+    populateFactsWidget: function(facts, ongoingFact) {
+
+        /**
+         * Construct an individual row within the widget - representing a single fact.
+         */
+        function constructRow(fact, ongoingFact, controller, menu) {
+            /**
+             * Check if two facts have the same activity.
+             */
+            function checkSameActivity(fact, otherFact) {
+                // Check if two facts have the same activity.
+                let result = true;
+                if (!otherFact ||
+                    otherFact.name != fact.name ||
+                    otherFact.category != fact.category ||
+                    // [FIXME]
+                    // This is wrong, isn't it? Tags 'belong' to facts, not
+                    // activities! We keep it for now and need to address this
+                    // as a single issue.
+                    otherFact.tags.join(",") != fact.tags.join(",")) {
+                        result = false;
+                    };
+                return result;
+            };
+
+            /**
+             * Callback for the 'openEditDialog'-Button.
+             *
+             * Opens the edit dialog and closes the extension 'drop down
+             *  bubble' menu.
+             *
+             * @callback TodaysFactsWidget~openEditDialog
+             */
+            function onOpenEditDialog(button, event) {
+                controller.windowsProxy.editSync(GLib.Variant.new('i', [fact.id]));
+                menu.close();
+            };
+
+            /**
+             * Callback for the 'onContinue'-Button.
+             *
+             * Start a new ongoing fact with this facts activity and tags.
+             * Closes the menu.
+             *
+             * @callback TodaysFactsWidget~onContinueButton
+             */
+            function onContinueButton(button, event) {
+                // [FIXME]
+                // This probably should be a "serialize" method of the fact object.
+                let fact = button.fact
+                let factStr = fact.name
+                  + "@" + fact.category
+                  + ", " + (fact.description);
+                if (fact.tags.length) {
+                    factStr += " #" + fact.tags.join(", #");
+                }
+
+                controller.apiProxy.AddFactRemote(factStr, 0, 0, false, Lang.bind(this, function(response, err) {
+                    // not interested in the new id - this shuts up the warning
+                }));
+                menu.close();
+            };
+
+            // Construct the ``Label`` rendering the start- and endtime information.
+            let timeLabel = new St.Label({style_class: 'cell-label'});
+            let timeString;
+            let start_string = "%02d:%02d - ".format(fact.startTime.getHours(), fact.startTime.getMinutes());
+            if (fact.endTime) {
+                let end_string = "%02d:%02d".format(fact.endTime.getHours(), fact.endTime.getMinutes());
+                timeString = start_string + end_string
+            } else {
+                timeString = start_string
+            };
+            timeLabel.set_text(timeString);
+
+            // Construct the ``Label``rendering the remaining fact info.
+            let factLabel = new St.Label({style_class: 'cell-label'});
+            // [FIXME]
+            // This needs to be cleaner!
+            factLabel.set_text(fact.name + (0 < fact.tags.length ? (" #" + fact.tags.join(", #")) : ""));
+
+            // Construct the ``Label rendering the facts duration.
+            let deltaLabel = new St.Label({style_class: 'cell-label'});
+            deltaLabel.set_text(Stuff.formatDurationHuman(fact.delta));
+
+            // Construct a button that triggers 'edit' dialog.
+            let editIcon = new St.Icon({icon_name: "document-open-symbolic", icon_size: 16});
+            let editButton = new St.Button({style_class: 'clickable cell-button'});
+            editButton.set_child(editIcon);
+            // [FIXME]
+            // Wouldn't it be cleaner to pass the fact as data payload to the callback binding?
+            editButton.connect('clicked', Lang.bind(this, onOpenEditDialog));
+
+            // Construct a 'start previous fact's activity as new' button.
+            // This is only done if the *ongoing fact* activity is actually
+            // different from the one we currently process.
+            let continueButton = null
+            if (!checkSameActivity(fact, ongoingFact)) {
+
+                let continueIcon = new St.Icon({icon_name: "media-playback-start-symbolic", icon_size: 16});
+                continueButton = new St.Button({style_class: 'clickable cell-button'});
+                continueButton.set_child(continueIcon);
+                continueButton.fact = fact;
+                continueButton.connect('clicked', Lang.bind(this, onContinueButton));
+            };
+
+            //The order of the array will be the order in which they will be added to the row.
+            let result = [timeLabel, factLabel, deltaLabel, editButton];
+
+            if (continueButton) {
+                result.push(continueButton);
+            };
+            return result
+
+        };
+
+        let rowCount = 0;
+        let layout = this.facts_widget.layout_manager;
+        for (let fact of facts) {
+            let rowComponents = constructRow(fact, ongoingFact, this._controller, this._panelWidget.menu);
+            for (let component of rowComponents) {
+                layout.pack(component, rowComponents.indexOf(component), rowCount);
+            };
+            rowCount += 1;
+        };
+    },
+
+    /**
+     * Clear the widget and populate it anew.
+     */
+    refresh: function(facts, ongoingFact) {
+        this.facts_widget.destroy_all_children();
+        this.populateFactsWidget(facts, ongoingFact)
+    },
+});


### PR DESCRIPTION
This commit provides a major reorganization and refactoring of our main
codebase. In general three main objectives are persued in this.
1. Instead of few extensive functions with intransparent shared state
   and monkey patching we try to split our codebase into various decoupled
   objects. The main idea is to split up each individual "widget" into its
   own proper class and have it handle all but only the logic it is really
   concerned with. This has several benefits. For one it is far more
   transparent which parameters are relevant to the widget. Secondly: if we
   need to have some sort of state it is confined to the widget that
   actually needs it. Third: All logic happens right where it is relevant.
   That should make the code much more maintainable as contributors do not
   have to browse thorugh the entire codebase out of fear that there may be
   unforeseen sideeffects through monkey patching. Furthermore, we aim to
   have a clear distinction between public and private interfaces, further
   incerasing developer confidence about the contracts between objects.
   This is of particular relevance when it comes to "refreshing/updateting"
   widgets. Each widget just implements its own "refresh" logic (making
   things much more accessable) and then gets called once a global
   "refresh" is triggered.
2. Dead, obsolete code that was not used at all has been removed. So
   were unused imports. We also tried to consolidate the allover code style
   and naming scheme. We did not go all the way with this in order to avoid
   blowin up the scope of the PR even more and making code review even
   harder. For now we tried to fix the worst offenders and leave the rest
   to a second itteration.
3. We moved each individual widget class into its own seperate file and
   placed them under the `widgets` sub-module. This makes for a clear and
   transparent namespace as well filesystem structure.

As an additional bonus, we started some rudimentary introduction of
proper docstrings using the 'jsdoc' syntax (http://usejsdoc.org/).

General implementation notes:
- Instead of adding more one-off functions to the `Stuff` sub-module we
  make heavy use of local functions now. While, javascript being
  javascript, this looks a bit confusing at first it ensures that
  functions and implementation details relevant to only a very specific
  part of the codebase are close by and do not distract developers dealing
  with entirely different code regions.
- We make heavy use of the `let` keyword now (where the old code used
  `var`) as in most cases variable declaration was relevant only in a
  very limited scope and `let` is more memory efficient in that case. I
  doubt there is any measureable difference, but it seems like good
  practive.
- In general, we tried not to get too carried away with refactoring
  algorithms and special implementations as well as to limit the scope
  of the PR but to focus on the general code layout and structure. Instead
  I made liberal use of [FIXME] tags to indicate parts that warrent
  revisiting in order to have another look on specific aspects of the code
  and the way things are done.

For general reference and ease of transition:
We renamed our main objects to better reflect what they actually do as
well as removed redundant `Hamster` prefixes:
- `HamsterControler` -> `Controler`
- `HamsterExtension` -> `PanelWidget`
- `HamsterBox` -> `->`FactsBox``

Attention:
We have changed some of previously asyncronous dbus method calls
`*Remote` to their syncronous `*Sync` version as it seems more
fitting as well as less likely to create race conditions.
There may however be a risk of freezing the entire shell if those calls
time out (which may be an issue in future if the dbus service uses a
remote db as persistent storage).
We will have to keep an eye on this. We should be ok for now.
