### PR TITLE
Feature/154 add gnome shell 3 22 compability

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Development Lead
 
 Contributors
 ------------
+* Richard Stangl (github: @rstangl)
 
 Original Authors (pre 0.10.0)
 ------------------------------

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -19,5 +19,5 @@
     ],
     "url": "https://github.com/projecthamster/shell-extension.git",
     "uuid": "hamster@projecthamster.wordpress.com",
-    "version": 0.10.0
+    "version": "0.10.0"
 }


### PR DESCRIPTION
Fix version string in metadata.json

Without "" a parse error was caused in gnome-shell 3.22

JS ERROR: Could not load extension hamster@projecthamster.wordpress.com: Error: Failed to parse metadata.json: SyntaxError: JSON.parse: expected ',' or '}' after property value in object