### PR TITLE
Fix syntax error in metadata.json

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Development Lead
 
 Contributors
 ------------
+* Richard Stangl (github: @rstangl)
 
 Original Authors (pre 0.10.0)
 ------------------------------

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -19,5 +19,5 @@
     ],
     "url": "https://github.com/projecthamster/shell-extension.git",
     "uuid": "hamster@projecthamster.wordpress.com",
-    "version": 0.10.0
+    "version": "0.10.0"
 }


### PR DESCRIPTION
Without "" a parse error was caused in gnome-shell-3.22