### PR TITLE
[#192] Fix variable redeclarations causing TypeError on 3.24

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -364,7 +364,7 @@ HamsterExtension.prototype = {
 
         var i = 0;
         let layout = activities.layout_manager;
-        for (var fact of facts) {
+        for (fact of facts) {
             let label;
 
             label = new St.Label({style_class: 'cell-label'});
@@ -434,7 +434,7 @@ HamsterExtension.prototype = {
 
         let byCategory = {};
         let categories = [];
-        for (var fact of facts) {
+        for (fact of facts) {
             byCategory[fact.category] = (byCategory[fact.category] || 0) + fact.delta;
             if (categories.indexOf(fact.category) == -1)
                 categories.push(fact.category);

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,9 @@
         "3.14",
         "3.16",
         "3.18",
-        "3.20"
+        "3.20",
+        "3.22",
+        "3.24"
     ],
     "url": "https://github.com/projecthamster/shell-extension.git",
     "uuid": "hamster@projecthamster.wordpress.com",

--- a/prefs.js
+++ b/prefs.js
@@ -65,7 +65,7 @@ const HamsterSettingsWidget = new GObject.Class({
 
         let appearanceCombo = new Gtk.ComboBox({model: appearanceOptions});
 
-        let renderer = new Gtk.CellRendererText();
+        renderer = new Gtk.CellRendererText();
         appearanceCombo.pack_start(renderer, true);
         appearanceCombo.add_attribute(renderer, 'text', 0);
         appearanceCombo.connect('changed', Lang.bind(this, this._onAppearanceChange));


### PR DESCRIPTION
GNOME Shell 3.24 now uses mozjs38 (SpiderMonkey 38) which has
stricter syntax rules.
https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey

In particular, it errors out on redeclarations of a variable inside
of a code block.

Typical gnome-shell errors emitted by 3.24 look like this
(unfortunately, no reference to the actually offending code in
the extension except for the variable name):

JS ERROR: Exception in callback for signal: extension-found: TypeError: redeclaration of let fact
initExtension@resource:///org/gnome/shell/ui/extensionSystem.js:221:5
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:168:18
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:304:9
_emit@resource:///org/gnome/gjs/modules/signals.js:126:27
ExtensionFinder<._loadExtension@resource:///org/gnome/shell/misc/extensionUtils.js:184:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
bind/<@resource:///org/gnome/gjs/modules/lang.js:95:16
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:1
ExtensionFinder<.scanExtensions@resource:///org/gnome/shell/misc/extensionUtils.js:189:9
wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:306:5
enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:314:9
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:345:9
init@resource:///org/gnome/shell/ui/extensionSystem.js:353:5
_initializeUI@resource:///org/gnome/shell/ui/main.js:219:5
start@resource:///org/gnome/shell/ui/main.js:127:5
@<main>:1:31

Fix this, and indicate gnome-shell 3.24 compatibility in metadata.json
(not strictly needed any more, but may increase user confidence).