### PR TITLE
[#172] Update supported shell versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ Install For Production
 ~~~~~~~~~~~~~~~~~~~~~~~
 The extension is available on `the central extension repository <https://extensions.gnome.org/extension/425/project-hamster-extension>`_.
 
-Current compatible Gnome shell version: 3.20
-For previous shell versions check `releases <https://github.com/projecthamster/shell-extension/tags>`_.
+Current compatible Gnome shell version: 3.24
+For previous shell versions check `releases <https://github.com/projecthamster/hamster-shell-extension/tags>`_.
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Shell extension for Hamster - the GNOME time tracker. File your issues here: https://github.com/projecthamster/shell-extension/issues",
+    "description": "Shell extension for Hamster - the GNOME time tracker. File your issues here: https://github.com/projecthamster/hamster-shell-extension/issues",
     "extension-id": "project-hamster",
     "name": "Hamster Time Tracker",
     "original-authors": [
@@ -15,9 +15,10 @@
         "3.16",
         "3.18",
         "3.20",
-        "3.22"
+        "3.22",
+        "3.24"
     ],
-    "url": "https://github.com/projecthamster/shell-extension.git",
+    "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": "contact@projecthamster.org",
     "version": "0.10.0"
 }


### PR DESCRIPTION
This updates the metadata to claim gnome-shell 3.22 and 2.24 as supported versions.

Closes: #172 