### PR TITLE
Update manual installation instruction in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,20 @@ changing you main environment.
 
 Manual Installation For Testing and Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To install just run ``make dist`` do create a distributable archive.
-You can now you the ``tweaktool`` (at the bottom of the ``extensions`` tab)
+Clone the repository::
+
+    git clone git@github.com:projecthamster/hamster-shell-extension.git
+
+Make sure you are on the development branch::
+
+    git checkout develop
+
+Build a fresh distribution package::
+
+    make dist
+
+This will create a distributable archive.
+You can now use the ``tweaktool`` (at the bottom of the ``extensions`` tab)
 to install and activate the new ``zip`` file located in the ``dist`` directory.
 
 Alternatively you just can unpack the tar archive to ``~/.local/share/gnome-shell/extensions/``.


### PR DESCRIPTION
Doe to the cleaned up build process it is no longer possible to simply link to the repository in order to "install" the extension.
This PR includes basic documentation on how to "build" and install straight from the repository under the new system.