### PR TITLE
Fix automatic refresh of the panel widget

### DIFF
--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -192,6 +192,7 @@ const PanelWidget = new Lang.Class({
     // Once this is done, the actual code from the callback should follow
     // here.
     this._controller.apiProxy.GetTodaysFactsRemote(Lang.bind(this, _refresh));
+    return GLib.SOURCE_CONTINUE;
     },
 
     /**


### PR DESCRIPTION
This widget installs a GSourceFunc to be triggered on a 60 seconds timeout
but it does not explicitly return GLib.SOURCE_CONTINUE in the callback,
meaning that the source will be removed after it gets called once, leaving
the label outdated forever.

This fixes this problem by explicitly returning GLib.SOURCE_CONTINUE there.

https://github.com/projecthamster/hamster-shell-extension/issues/189