### PR TITLE
[#62] Ensure dbus services are present

### DIFF
--- a/extension/stuff.js
+++ b/extension/stuff.js
@@ -55,7 +55,7 @@ function fromDbusFact(fact) {
         return new Date(res.setUTCMinutes(res.getUTCMinutes() + res.getTimezoneOffset()));
     }
 
-    result = {
+    let result = {
         name: fact[4],
         startTime: UTCToLocal(fact[1]*1000),
         endTime: fact[2] != 0 ? UTCToLocal(fact[2]*1000) : null,


### PR DESCRIPTION
This PR uses ``Gio.bus_watch_name`` to make sure
appearing/vanishing hamster dbus services are handled accordingly.
Right now we only act on vanishing/not running services by triggering
``disable``. Future itteration could consider being a bit more
forgiving, but for now this should help to make potential issues
attributed to the extension that are really caused by the dbus service
more clear.

Closes: #62 
