### PR TITLE
properly format hours to show

### DIFF
--- a/extension/stuff.js
+++ b/extension/stuff.js
@@ -80,7 +80,7 @@ function formatDurationHours(seconds) {
     let hours = Math.round((seconds/3600)*10);
     // Shift right after rounding.
     hours = hours / 10;
-    return '%2dh'.format(hours);
+    return '%.1fh'.format(hours);
 }
 
 // Other helper functions


### PR DESCRIPTION
I'm pretty sure this used to work, at least in the version I had,
but now it showed only hours instead of fractions thereof.