### PR TITLE
Fix multiple gjs warnings and avoid crashing on refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://git.gnome.org/browse/gnome-shell-extensions/plain/lib/convenience.js -P $(BUILDDIR)
+	wget https://git.gnome.org/browse/gnome-shell-extensions/plain/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile:
 	glib-compile-schemas $(BUILDDIR)/schemas

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -127,11 +127,11 @@ function Controller(extensionMeta) {
             // Set-up watchers that watch for required dbus services.
             let dbus_watcher = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster',
                 Gio.BusNameWatcherFlags.NONE, apiProxy_appeared_callback.bind(this),
-                apiProxy_vanished_callback.bind(this), '');
+                apiProxy_vanished_callback.bind(this));
 
             let dbus_watcher_window = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster.WindowServer',
                 Gio.BusNameWatcherFlags.NONE, windowsProxy_appeared_callback.bind(this),
-                windowsProxy_vanished_callback.bind(this), '');
+                windowsProxy_vanished_callback.bind(this));
 
             this.apiProxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
             this.activities = this.refreshActivities();

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -33,7 +33,7 @@ const Stuff = Me.imports.stuff;
 /**
  * Custom Label widget that displays category totals.
  */
-const CategoryTotalsWidget = new Lang.Class({
+var CategoryTotalsWidget = new Lang.Class({
     Name: 'CategoryTotals',
     Extends: St.Label,
 

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -40,7 +40,7 @@ const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
  * well as todays facts.
  * @class
  */
-const FactsBox = new Lang.Class({
+var FactsBox = new Lang.Class({
     Name: 'FactsBox',
     Extends: PopupMenu.PopupBaseMenuItem,
     _init: function(controller, panelWidget) {

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -36,7 +36,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
  *
  *
  */
-const OngoingFactEntry = new Lang.Class({
+var OngoingFactEntry = new Lang.Class({
     Name: 'OngoingFactEntry',
     Extends: St.Entry,
 

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -52,7 +52,7 @@ const Stuff = Me.imports.stuff;
  *
  * @class
  */
-const PanelWidget = new Lang.Class({
+var PanelWidget = new Lang.Class({
     Name: 'PanelWidget',
     Extends: PanelMenu.Button,
 

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -33,7 +33,7 @@ const Stuff = Me.imports.stuff;
 /**
  * A widget that lists all facts for *today*.
  */
-const TodaysFactsWidget = new Lang.Class({
+var TodaysFactsWidget = new Lang.Class({
     Name: 'TodaysFactsWidget',
     Extends: St.ScrollView,
 


### PR DESCRIPTION
I was so annoyed by the regular gnome-shell crashes triggered by this extension that I tried to debug and fix the issue myself. When I started on this, I noticed a few gjs warnings that I opted to fix first to clean up my view and better see real errors. But it turns out that once I fixed the warning about Gio.bus_watch_name() then I would no longer be able to reproduce the crash and the delay reported in #205 that I was also experiencing is gone.

Fixes #205, #198 