### PR TITLE
[#198][#205] Minor syntax fixes, Improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://git.gnome.org/browse/gnome-shell-extensions/plain/lib/convenience.js -P $(BUILDDIR)
+	wget https://git.gnome.org/browse/gnome-shell-extensions/plain/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile:
 	glib-compile-schemas $(BUILDDIR)/schemas

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -127,11 +127,11 @@ function Controller(extensionMeta) {
             // Set-up watchers that watch for required dbus services.
             let dbus_watcher = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster',
                 Gio.BusNameWatcherFlags.NONE, apiProxy_appeared_callback.bind(this),
-                apiProxy_vanished_callback.bind(this), '');
+                apiProxy_vanished_callback.bind(this));
 
             let dbus_watcher_window = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster.WindowServer',
                 Gio.BusNameWatcherFlags.NONE, windowsProxy_appeared_callback.bind(this),
-                windowsProxy_vanished_callback.bind(this), '');
+                windowsProxy_vanished_callback.bind(this));
 
             this.apiProxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
             this.activities = this.refreshActivities();

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -33,7 +33,7 @@ const Stuff = Me.imports.stuff;
 /**
  * Custom Label widget that displays category totals.
  */
-const CategoryTotalsWidget = new Lang.Class({
+var CategoryTotalsWidget = new Lang.Class({
     Name: 'CategoryTotals',
     Extends: St.Label,
 

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -40,7 +40,7 @@ const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
  * well as todays facts.
  * @class
  */
-const FactsBox = new Lang.Class({
+var FactsBox = new Lang.Class({
     Name: 'FactsBox',
     Extends: PopupMenu.PopupBaseMenuItem,
     _init: function(controller, panelWidget) {

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -36,7 +36,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
  *
  *
  */
-const OngoingFactEntry = new Lang.Class({
+var OngoingFactEntry = new Lang.Class({
     Name: 'OngoingFactEntry',
     Extends: St.Entry,
 

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -52,7 +52,7 @@ const Stuff = Me.imports.stuff;
  *
  * @class
  */
-const PanelWidget = new Lang.Class({
+var PanelWidget = new Lang.Class({
     Name: 'PanelWidget',
     Extends: PanelMenu.Button,
 

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -33,7 +33,7 @@ const Stuff = Me.imports.stuff;
 /**
  * A widget that lists all facts for *today*.
  */
-const TodaysFactsWidget = new Lang.Class({
+var TodaysFactsWidget = new Lang.Class({
     Name: 'TodaysFactsWidget',
     Extends: St.ScrollView,
 


### PR DESCRIPTION
This PR is a direct copy of Raphaël Hertzog work (#217 ) with just minor (mostly markdown related) changes to commit messages.

This PR does tree things:
- Avoid creation of duplicated convinience.js files
- Use ``var`` instead of ``const`` to export variables
- Fix broken argument list for ``Gio.bus_watch_name()``

In effect this seems to fix several outstanding bugs.
For the original PR message and further information please refer to #217 

Fixes #205 #198 