### PR TITLE
[#212] Avoid crashes due to accessing destroyed objects

### DIFF
--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -189,7 +189,7 @@ var TodaysFactsWidget = new Lang.Class({
      * Clear the widget and populate it anew.
      */
     refresh: function(facts, ongoingFact) {
-        this.facts_widget.destroy_all_children();
+        this.facts_widget.remove_all_children();
         this.populateFactsWidget(facts, ongoingFact)
     },
 });


### PR DESCRIPTION
The crashes that I have been experiencing all have backtraces leading
back to the "refresh" event and error messages explaining that we are
trying to use objects that have been destroyed.

This is the only place where we are destroying objects explicitly
instead of relying on the garbage collector. To fix the crash, I'm
simply using the `remove_all_children()` method instead of the
`destroy_all_children()` one.

Fixes #212