### PR TITLE
[#240] Clear apiProxy & windowsProxy on disable()

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -189,6 +189,8 @@ function Controller(extensionMeta) {
             this.panelWidget.actor.destroy();
             this.panelWidget.destroy();
             this.panelWidget = null;
+            this.apiProxy = null;
+            this.windowsProxy = null;
         },
 
         /**


### PR DESCRIPTION
Sorry for the late discovery. :(
I'm not sure if it fixes anything important, but at least fixes some warnings and prevents deferred_enable() to be called multiple times after disable/enable.

Closes: #240 