### PR TITLE
[#228] Add basic style checks on CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+install:
+  - npm i -g jshint
+
+script:
+  - make test-style


### PR DESCRIPTION
This basic CI setup simply fetches ``jshint`` via ``npm`` and runs the
style checks.

Closes: #228