### PR TITLE
[#253] Improve i18n generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,17 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
 	@echo "   clean"
-	@echo "   clean-build  to clean the build directory of any leftovers."
+	@echo "   clean-build		to clean the build directory of any leftovers."
 	@echo "   clean-docs"
-	@echo "   collect      to collect all required files to the build directory."
-	@echo "   compile      to compile file that needs to be shipped as a binary."
-	@echo "   develop      to install (or update) all packages required for development"
-	@echo "   dist         to package a release as a ready to deploy extension archive"
-	@echo "   open-docs    to build and open the documentation"
-	@echo "   test-style   to run the code against a set of stylechecks and linter."
-	@echo "                (Requires JSHint)."
-	@echo "   test-docs    to run automated tests on the documentation."
+	@echo "   collect			to collect all required files to the build directory."
+	@echo "   compile			to compile file that needs to be shipped as a binary."
+	@echo "   develop			to install (or update) all packages required for development"
+	@echo "   dist				to package a release as a ready to deploy extension archive"
+	@echo "   gettext-catalogue to generate a new gettext catalogue"
+	@echo "   open-docs			to build and open the documentation"
+	@echo "   test-style		to run the code against a set of stylechecks and linter."
+	@echo "						(Requires JSHint)."
+	@echo "   test-docs			to run automated tests on the documentation."
 
 clean: clean-build clean-docs clean-test-docs
 	rm -f dist/*
@@ -60,6 +61,11 @@ collect:
 compile:
 	glib-compile-schemas $(BUILDDIR)/schemas
 	find $(BUILDDIR) -name \*.po -execdir msgfmt hamster-shell-extension.po -o hamster-shell-extension.mo \;
+
+gettext-catalogue:
+	find ./extension/ -type f -name '*.js' -print > list
+	xgettext -L JavaScript --from-code=UTF-8 --files-from=list -k_ -kN_ -o  ./messages.pot
+	rm ./list
 
 develop:
 	pip install -U pip setuptools wheel

--- a/data/locale/cs/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/cs/LC_MESSAGES/hamster-shell-extension.po
@@ -2,50 +2,59 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-17 16:42+0100\n"
-"PO-Revision-Date: 2013-01-13 01:18+0100\n"
+"POT-Creation-Date: 2018-03-12 01:39+0100\n"
+"PO-Revision-Date: 2018-03-12 01:39+0100\n"
 "Last-Translator: Martin Filip <nexus@smoula.net>\n"
+"Language-Team: \n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
-"Language-Team: \n"
-"X-Generator: Poedit 1.5.4\n"
 
-#: extension.js:85
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Co děláš?"
 
-#: extension.js:91
-msgid "Enter activity..."
-msgstr "Zadej aktivitu..."
-
-#: extension.js:105
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Dnešní aktivity"
 
-#: extension.js:215
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Zadej aktivitu..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Načítám..."
 
-#: extension.js:238
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Zobrazit přehled"
 
-#: extension.js:243
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Zastavit sledování"
 
-#: extension.js:249
+#: widgets/panelWidget.js:115
+msgid "Add Earlier Activity"
+msgstr "Zadat dřívější aktivity"
+
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Nastavení sledování"
 
-#: extension.js:398
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Žádná aktivita"
 
-#: extension.js:254
-msgid "Add Earlier Activity"
-msgstr "Zadat dřívější aktivity"
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/de/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/de/LC_MESSAGES/hamster-shell-extension.po
@@ -2,9 +2,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-18 13:27+0200\n"
-"PO-Revision-Date: 2014-06-18 13:33+0200\n"
-"Last-Translator: <bwcknr@gmail.com>\n"
+"POT-Creation-Date: 2018-03-12 01:37+0100\n"
+"PO-Revision-Date: 2018-03-12 01:38+0100\n"
+"Last-Translator: bwcknr@gmail.com\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -12,38 +12,51 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:98
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Was machen Sie gerade?"
 
-#: extension.js:104
-msgid "Enter activity..."
-msgstr "Tätigkeit starten..."
-
-#: extension.js:115
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Heutige Tätigkeiten"
 
-#: extension.js:254
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Tätigkeit starten..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Lade..."
 
-#: extension.js:278
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Übersicht anzeigen"
 
-#: extension.js:283
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Erfassung anhalten"
 
-#: extension.js:288
+#: widgets/panelWidget.js:115
 msgid "Add Earlier Activity"
 msgstr "Frühere Tätigkeit hinzufügen"
 
-#: extension.js:294
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Erfassungseinstellungen"
 
-#: extension.js:456
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Keine Tätigkeit"
+
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+"hamster-shell-extension: \"hamster-service\" läuft nicht. Fahre herunter."
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""
+"hamster-shell-extension: \"hamster-window-service\" läuft nicht. Fahre "
+"herunter."

--- a/data/locale/es/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/es/LC_MESSAGES/hamster-shell-extension.po
@@ -2,49 +2,59 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-17 16:42+0100\n"
-"PO-Revision-Date: 2015-10-24 15:02-0300\n"
+"POT-Creation-Date: 2018-03-12 01:39+0100\n"
+"PO-Revision-Date: 2018-03-12 01:39+0100\n"
 "Last-Translator: Matías Croce <mati@nelumboweb.com.ar>\n"
 "Language-Team: Piotr Plenik <piotr.plenik@teamlab.pl>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 1.8.6\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
-#: extension.js:85
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "¿Que estas haciendo?"
 
-#: extension.js:91
-msgid "Enter activity..."
-msgstr "Introduzca actividad..."
-
-#: extension.js:105
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Actividades de hoy"
 
-#: extension.js:215
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Introduzca actividad..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Cargando..."
 
-#: extension.js:238
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Mostrar Resumen"
 
-#: extension.js:243
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Detener Seguimiento"
 
-#: extension.js:249
+#: widgets/panelWidget.js:115
+msgid "Add Earlier Activity"
+msgstr "Añadir Actividad Anterior"
+
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Preferencias"
 
-#: extension.js:398
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Sin actividad"
 
-#: extension.js:254
-msgid "Add Earlier Activity"
-msgstr "Añadir Actividad Anterior"
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/fr/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/fr/LC_MESSAGES/hamster-shell-extension.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-17 16:42+0100\n"
-"PO-Revision-Date: 2012-11-13 12:27+0100\n"
+"POT-Creation-Date: 2018-03-12 01:40+0100\n"
+"PO-Revision-Date: 2018-03-12 01:40+0100\n"
 "Last-Translator: Raphaël Doursenaud <rdoursenaud@free.fr>\n"
 "Language-Team: français <>\n"
 "Language: fr_FR\n"
@@ -14,40 +14,49 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"X-Generator: Gtranslator 2.91.5\n"
 
-#: extension.js:85
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Que faîtes vous ?"
 
-#: extension.js:91
-msgid "Enter activity..."
-msgstr "Entrez l'activité…"
-
-#: extension.js:105
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Activités du jour"
 
-#: extension.js:215
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Entrez l'activité…"
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Chargement…"
 
-#: extension.js:238
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Montrer le résumé"
 
-#: extension.js:243
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Arrêter le suivi"
 
-#: extension.js:249
+#: widgets/panelWidget.js:115
+msgid "Add Earlier Activity"
+msgstr "Ajouter une activité antérieure"
+
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Préférences"
 
-#: extension.js:398
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Pas d'activité"
 
-#: extension.js:254
-msgid "Add Earlier Activity"
-msgstr "Ajouter une activité antérieure"
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/nl/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/nl/LC_MESSAGES/hamster-shell-extension.po
@@ -2,9 +2,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-06-18 13:27+0200\n"
-"PO-Revision-Date: 2014-06-18 13:33+0200\n"
-"Last-Translator: <bwcknr@gmail.com>\n"
+"POT-Creation-Date: 2018-03-12 01:42+0100\n"
+"PO-Revision-Date: 2018-03-12 01:42+0100\n"
+"Last-Translator: bwcknr@gmail.com\n"
 "Language-Team: Dutch\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -12,38 +12,48 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:98
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Wat ben je aan het doen?"
 
-#: extension.js:104
-msgid "Enter activity..."
-msgstr "Activiteit starten..."
-
-#: extension.js:115
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Huidige activiteiten"
 
-#: extension.js:254
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Activiteit starten..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Laden..."
 
-#: extension.js:278
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Overzicht tonen"
 
-#: extension.js:283
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Registratie stoppen"
 
-#: extension.js:288
+#: widgets/panelWidget.js:115
 msgid "Add Earlier Activity"
 msgstr "Eerdere activiteit toevoegen"
 
-#: extension.js:294
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Registratieinstellingen"
 
-#: extension.js:456
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Geen activiteit"
+
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/pl/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/pl/LC_MESSAGES/hamster-shell-extension.po
@@ -2,51 +2,59 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-17 16:42+0100\n"
-"PO-Revision-Date: 2012-10-01 11:14+0100\n"
+"POT-Creation-Date: 2018-03-12 01:42+0100\n"
+"PO-Revision-Date: 2018-03-12 01:42+0100\n"
 "Last-Translator: Daniel Craig <daniel@danielcraig.me>\n"
 "Language-Team: Piotr Plenik <piotr.plenik@teamlab.pl>\n"
-"Language: \n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Poedit-Language: Polish\n"
-"X-Poedit-Country: Poland\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 
-#: extension.js:85
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Co robisz?"
 
-#: extension.js:91
-msgid "Enter activity..."
-msgstr "Wpisz aktywność..."
-
-#: extension.js:105
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Dzisiejsze aktywności"
 
-#: extension.js:215
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Wpisz aktywność..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Ładowanie..."
 
-#: extension.js:238
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Przegląd sprawozdania"
 
-#: extension.js:243
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Zatrzymaj śledzenie"
 
-#: extension.js:249
-msgid "Tracking Settings"
-msgstr "Preferencje programu"
-
-#: extension.js:398
-msgid "No activity"
-msgstr "Brak aktywności"
-
-#: extension.js:254
+#: widgets/panelWidget.js:115
 msgid "Add Earlier Activity"
 msgstr "Dodaj wcześniejszą czynność"
 
+#: widgets/panelWidget.js:121
+msgid "Tracking Settings"
+msgstr "Preferencje programu"
+
+#: widgets/panelWidget.js:227
+msgid "No activity"
+msgstr "Brak aktywności"
+
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/pt-BR/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/pt-BR/LC_MESSAGES/hamster-shell-extension.po
@@ -2,49 +2,57 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-07 10:04-0300\n"
-"PO-Revision-Date: 2015-10-07 10:15-0300\n"
+"POT-Creation-Date: 2018-03-12 01:43+0100\n"
+"PO-Revision-Date: 2018-03-12 01:43+0100\n"
+"Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
-"Language-Team: \n"
-"X-Generator: Poedit 1.7.5\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
 
-#: extension.js:98
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "O que você está fazendo?"
 
-#: extension.js:104
-msgid "Enter activity..."
-msgstr "Digite a atividade..."
-
-#: extension.js:115
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Atividades de hoje"
 
-#: extension.js:261
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Digite a atividade..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: extension.js:285
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Exibir visão geral"
 
-#: extension.js:290
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Parar rastreamento"
 
-#: extension.js:295
+#: widgets/panelWidget.js:115
 msgid "Add Earlier Activity"
 msgstr "Adicionar atividade anterior"
 
-#: extension.js:301
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Configurações do rastreamento"
 
-#: extension.js:463
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Sem atividade"
+
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""

--- a/data/locale/ru/LC_MESSAGES/hamster-shell-extension.po
+++ b/data/locale/ru/LC_MESSAGES/hamster-shell-extension.po
@@ -2,49 +2,59 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hamster-shell-extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-17 16:42+0100\n"
-"PO-Revision-Date: 2015-02-25 01:15+0300\n"
+"POT-Creation-Date: 2018-03-12 01:43+0100\n"
+"PO-Revision-Date: 2018-03-12 01:43+0100\n"
 "Last-Translator: Daniel Craig <daniel@danielcraig.me>\n"
 "Language-Team: Egor Garadja <egor.garadja@gmail.com>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"X-Generator: Poedit 1.7.4\n"
-"Language: ru\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: extension.js:85
+#: widgets/factsBox.js:58
 msgid "What are you doing?"
 msgstr "Чем вы заняты?"
 
-#: extension.js:91
-msgid "Enter activity..."
-msgstr "Занятие..."
-
-#: extension.js:105
+#: widgets/factsBox.js:66
 msgid "Today's activities"
 msgstr "Сегодня"
 
-#: extension.js:215
+#: widgets/ongoingFactEntry.js:48
+msgid "Enter activity..."
+msgstr "Занятие..."
+
+#: widgets/panelWidget.js:82
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#: extension.js:238
+#: widgets/panelWidget.js:103
 msgid "Show Overview"
 msgstr "Обзор"
 
-#: extension.js:243
+#: widgets/panelWidget.js:110
 msgid "Stop Tracking"
 msgstr "Прекратить учёт"
 
-#: extension.js:249
+#: widgets/panelWidget.js:115
+msgid "Add Earlier Activity"
+msgstr "Добавить раннее занятие"
+
+#: widgets/panelWidget.js:121
 msgid "Tracking Settings"
 msgstr "Параметры"
 
-#: extension.js:398
+#: widgets/panelWidget.js:227
 msgid "No activity"
 msgstr "Нет записей"
 
-#: extension.js:254
-msgid "Add Earlier Activity"
-msgstr "Добавить раннее занятие"
+#: extension.js:113 extension.js:114
+msgid "hamster-shell-extension: 'hamster-service' not running. Shutting down."
+msgstr ""
+
+#: extension.js:122 extension.js:123
+msgid ""
+"hamster-shell-extension: 'hamster-windows-service' not running. Shutting "
+"down."
+msgstr ""


### PR DESCRIPTION
Provide a dedicated `gettext-catalogue` make target to generate an up to date gettext catalogue (`po`) file.

Closes: #253 