### PR TITLE
[#255] Add 'test-docs' to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-language: node_js
+language: python
 
 install:
+  - pip install -r requirements.pip
   - npm i -g jshint
 
 script:
   - make test-style
+  - make test-docs


### PR DESCRIPTION
As building and testing the docs is depend on several python packaged, we change the travis setup accordingly.

Closes: #255